### PR TITLE
Add GetSpecMessage method to type wrappers

### DIFF
--- a/pkg/apis/authentication/v1alpha1/policy.go
+++ b/pkg/apis/authentication/v1alpha1/policy.go
@@ -15,6 +15,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"github.com/golang/protobuf/proto"
 	istiov1alpha1 "istio.io/api/authentication/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -29,6 +30,10 @@ type Policy struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec PolicySpec `json:"spec"`
+}
+
+func (p *Policy) GetSpecMessage() proto.Message {
+	return &p.Spec.Policy
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/networking/v1alpha3/destination_rule.go
+++ b/pkg/apis/networking/v1alpha3/destination_rule.go
@@ -15,6 +15,7 @@ limitations under the License.
 package v1alpha3
 
 import (
+	"github.com/golang/protobuf/proto"
 	istiov1alpha3 "istio.io/api/networking/v1alpha3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -29,6 +30,10 @@ type DestinationRule struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec DestinationRuleSpec `json:"spec"`
+}
+
+func (dr *DestinationRule) GetSpecMessage() proto.Message {
+	return &dr.Spec.DestinationRule
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/networking/v1alpha3/virtual_service.go
+++ b/pkg/apis/networking/v1alpha3/virtual_service.go
@@ -15,6 +15,7 @@ limitations under the License.
 package v1alpha3
 
 import (
+	"github.com/golang/protobuf/proto"
 	istiov1alpha3 "istio.io/api/networking/v1alpha3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -29,6 +30,10 @@ type VirtualService struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec VirtualServiceSpec `json:"spec"`
+}
+
+func (vs *VirtualService) GetSpecMessage() proto.Message {
+	return &vs.Spec.VirtualService
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
Problem:
To use the istio decoders on these types, they should implement a SpecMessageGetter
interface, so that the data can be decode using the protobuf unmarshalers

Solution:
Add a GetSpecMessage() method to each of the types