### PR TITLE
Fix for fake code-gen

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -47,6 +47,14 @@
   version = "v1.3.2"
 
 [[projects]]
+  digest = "1:05f95ffdfcf651bdb0f05b40b69e7f5663047f8da75c72d58728acb59b5cc107"
+  name = "github.com/google/btree"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "4030bb1f1f0c35b30ca7009e9ebd06849dd45306"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:52c5834e2bebac9030c97cc0798ac11c3aa8a39f098aeb419f142533da6cd3cc"
   name = "github.com/google/gofuzz"
   packages = ["."]
@@ -65,6 +73,17 @@
   pruneopts = "NUT"
   revision = "ab0dd09aa10e2952b28e12ecd35681b20463ebab"
   version = "v0.3.1"
+
+[[projects]]
+  branch = "master"
+  digest = "1:a86d65bc23eea505cd9139178e4d889733928fe165c7a008f41eaab039edf9df"
+  name = "github.com/gregjones/httpcache"
+  packages = [
+    ".",
+    "diskcache",
+  ]
+  pruneopts = "NUT"
+  revision = "901d90724c7919163f472a9812253fb26761123d"
 
 [[projects]]
   digest = "1:ed860d2b2c1d066d36a89c982eefc7d019badd534f60e87ab65d3d94f0797ef0"
@@ -115,6 +134,22 @@
   pruneopts = "NUT"
   revision = "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd"
   version = "1.0.1"
+
+[[projects]]
+  branch = "master"
+  digest = "1:89da0f0574bc94cfd0ac8b59af67bf76cdd110d503df2721006b9f0492394333"
+  name = "github.com/petar/GoLLRB"
+  packages = ["llrb"]
+  pruneopts = "NUT"
+  revision = "33fb24c13b99c46c93183c291836c573ac382536"
+
+[[projects]]
+  digest = "1:e1b94bd98c62fc2f905621fc6ba8209b7004e4513a1dfecb12a3de56ec2bb519"
+  name = "github.com/peterbourgon/diskv"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "0be1b92a6df0e4f5cb0a5d15fb7f643d0ad93ce6"
+  version = "v3.0.0"
 
 [[projects]]
   digest = "1:14715f705ff5dfe0ffd6571d7d201dd8e921030f8070321a79380d8ca4ec1a24"
@@ -299,10 +334,11 @@
   revision = "162827b552e84a48f0d9d45a8f10ea1623706663"
 
 [[projects]]
-  branch = "release-1.14"
-  digest = "1:f83b66888402b9a9adf7a1154f27e5b8299e67fe1de9d1e2d4ca17562345404a"
+  branch = "release-1.13"
+  digest = "1:c90ef886998c8f14bbb7a4fc6be3fe43f1f22e3f312de93baba7db0266c89186"
   name = "k8s.io/api"
   packages = [
+    "admissionregistration/v1alpha1",
     "admissionregistration/v1beta1",
     "apps/v1",
     "apps/v1beta1",
@@ -319,20 +355,15 @@
     "batch/v1beta1",
     "batch/v2alpha1",
     "certificates/v1beta1",
-    "coordination/v1",
     "coordination/v1beta1",
     "core/v1",
     "events/v1beta1",
     "extensions/v1beta1",
     "networking/v1",
-    "networking/v1beta1",
-    "node/v1alpha1",
-    "node/v1beta1",
     "policy/v1beta1",
     "rbac/v1",
     "rbac/v1alpha1",
     "rbac/v1beta1",
-    "scheduling/v1",
     "scheduling/v1alpha1",
     "scheduling/v1beta1",
     "settings/v1alpha1",
@@ -341,11 +372,11 @@
     "storage/v1beta1",
   ]
   pruneopts = "NUT"
-  revision = "e3a6b8045b0b303430f6d0c261fd9e35be50800e"
+  revision = "ebce17126a01f5fe02364d88c899816bcc2a8165"
 
 [[projects]]
-  branch = "release-1.14"
-  digest = "1:754bc618ffd9db9380bd8b4db61dd88e96fca6b4aaae996ad6d9972674bdf28f"
+  branch = "release-1.13"
+  digest = "1:8791110dece73ababc379d9dc9120868f8a3b0b9653ef6434bdc69c9e0fde814"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/errors",
@@ -392,11 +423,11 @@
     "third_party/forked/golang/reflect",
   ]
   pruneopts = "NUT"
-  revision = "a9f1d8a9c10182d101acf19b5145c3d4e9299adb"
+  revision = "bf4de9df677cd119930fa83483bad158956cdfcf"
 
 [[projects]]
-  branch = "release-11.0"
-  digest = "1:0246fe36c3f0bfeb140983438d81f558dbd3c3b3f2071209cf4651461fd83cb3"
+  branch = "release-10.0"
+  digest = "1:3cd3e00ca7ec0c9a2563c122da418e2b29db0db8a887a6ea57bdb8b70e8b72c6"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -419,19 +450,20 @@
     "tools/metrics",
     "tools/pager",
     "transport",
+    "util/buffer",
     "util/cert",
     "util/connrotation",
     "util/flowcontrol",
     "util/homedir",
-    "util/keyutil",
+    "util/integer",
     "util/retry",
   ]
   pruneopts = "NUT"
-  revision = "6d55c1b1f1ca8ad83d572bbc3ca55ba5526d9d71"
+  revision = "ee6c071a42cffd19361fc3f4ca995829328a0678"
 
 [[projects]]
-  branch = "release-1.14"
-  digest = "1:0ca40cba3558ea765d0e7fa91ebd32d661909d5c331c49c2a271af66f0b5604d"
+  branch = "release-1.13"
+  digest = "1:5172e9b7f4c508cbaad2b2a7e8f8e6e395f6d0a2895eae563bbded454a1c9a76"
   name = "k8s.io/code-generator"
   packages = [
     "cmd/client-gen",
@@ -442,11 +474,10 @@
     "cmd/client-gen/generators/util",
     "cmd/client-gen/path",
     "cmd/client-gen/types",
-    "pkg/namer",
     "pkg/util",
   ]
   pruneopts = ""
-  revision = "6c2a4329ac290d921e8616cad41635c87dbb1518"
+  revision = "1ed9df051d9b54e2eae92139efac94483e7354d4"
 
 [[projects]]
   branch = "master"
@@ -479,18 +510,6 @@
   revision = "743ec37842bffe49dd4221d9026f30fb1d5adbc4"
 
 [[projects]]
-  branch = "master"
-  digest = "1:2d3f59daa4b479ff4e100a2e1d8fea6780040fdadc177869531fe4cc29407f55"
-  name = "k8s.io/utils"
-  packages = [
-    "buffer",
-    "integer",
-    "trace",
-  ]
-  pruneopts = "NUT"
-  revision = "3d4f5b7dea0b7c63c77d7fb1f0ee433ad8d54667"
-
-[[projects]]
   digest = "1:8730e0150dfb2b7e173890c8b9868e7a273082ef8e39f4940e3506a481cf895c"
   name = "sigs.k8s.io/yaml"
   packages = ["."]
@@ -516,7 +535,6 @@
     "k8s.io/apimachinery/pkg/runtime/schema",
     "k8s.io/apimachinery/pkg/runtime/serializer",
     "k8s.io/apimachinery/pkg/types",
-    "k8s.io/apimachinery/pkg/util/runtime",
     "k8s.io/apimachinery/pkg/watch",
     "k8s.io/client-go/discovery",
     "k8s.io/client-go/discovery/fake",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,23 +2,23 @@
 
 
 [[projects]]
-  digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"
+  digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
   pruneopts = "NUT"
-  revision = "346938d642f2ec3594ed81d874461961cd0faa76"
-  version = "v1.1.0"
+  revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
+  version = "v1.1.1"
 
 [[projects]]
-  digest = "1:81466b4218bf6adddac2572a30ac733a9255919bc2f470b4827a317bd4ee1756"
-  name = "github.com/ghodss/yaml"
+  digest = "1:4304cca260ab815326ca42d9c28fb843342748267034c51963e13f5e54e727d1"
+  name = "github.com/evanphx/json-patch"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
-  version = "v1.0.0"
+  revision = "026c730a0dcc5d11f93f1cf1cc65b01247ea7b6f"
+  version = "v4.5.0"
 
 [[projects]]
-  digest = "1:895d2773c9e78e595dd5f946a25383d579d3094a9d8d9306dba27359f190f275"
+  digest = "1:ddeb4ef861c31ebe86546fa009a05f271454342eb89d99245f90531c327c7ac3"
   name = "github.com/gogo/protobuf"
   packages = [
     "gogoproto",
@@ -29,19 +29,11 @@
     "types",
   ]
   pruneopts = "NUT"
-  revision = "ba06b47c162d49f2af050fb4c75bcbc86a159d5c"
-  version = "v1.2.1"
+  revision = "0ca988a254f991240804bf9821f3450d87ccbb1b"
+  version = "v1.3.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:e2b86e41f3d669fc36b50d31d32d22c8ac656c75aa5ea89717ce7177e134ff2a"
-  name = "github.com/golang/glog"
-  packages = ["."]
-  pruneopts = "NUT"
-  revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
-
-[[projects]]
-  digest = "1:03e14cff610a8a58b774e36bd337fa979482be86aab01be81fb8bbd6d0f07fc8"
+  digest = "1:796f9c63c68774a89eade387a8476e45ec2b34f5649b0726983204202c3649d6"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
@@ -51,27 +43,19 @@
     "ptypes/timestamp",
   ]
   pruneopts = "NUT"
-  revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
-  version = "v1.1.0"
+  revision = "6c65a5562fc06764971b7c5d05c76c75e84bdbf7"
+  version = "v1.3.2"
 
 [[projects]]
-  branch = "master"
-  digest = "1:245bd4eb633039cd66106a5d340ae826d87f4e36a8602fcc940e14176fd26ea7"
-  name = "github.com/google/btree"
-  packages = ["."]
-  pruneopts = "NUT"
-  revision = "e89373fe6b4a7413d7acd6da1725b83ef713e6e4"
-
-[[projects]]
-  branch = "master"
   digest = "1:52c5834e2bebac9030c97cc0798ac11c3aa8a39f098aeb419f142533da6cd3cc"
   name = "github.com/google/gofuzz"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
+  revision = "f140a6486e521aad38f5917de355cbf147cc0496"
+  version = "v1.0.0"
 
 [[projects]]
-  digest = "1:06a7dadb7b760767341ffb6c8d377238d68a1226f2b21b5d497d2e3f6ecf6b4e"
+  digest = "1:5e092394bed250d7fda36cef8b7e1d22bb2d5f71878bbb137be5fc1c2705f965"
   name = "github.com/googleapis/gnostic"
   packages = [
     "OpenAPIv2",
@@ -79,38 +63,27 @@
     "extensions",
   ]
   pruneopts = "NUT"
-  revision = "7c663266750e7d82587642f65e60bc4083f1f84e"
-  version = "v0.2.0"
+  revision = "ab0dd09aa10e2952b28e12ecd35681b20463ebab"
+  version = "v0.3.1"
 
 [[projects]]
-  branch = "master"
-  digest = "1:7fdf3223c7372d1ced0b98bf53457c5e89d89aecbad9a77ba9fcc6e01f9e5621"
-  name = "github.com/gregjones/httpcache"
-  packages = [
-    ".",
-    "diskcache",
-  ]
-  pruneopts = "NUT"
-  revision = "9cad4c3443a7200dd6400aef47183728de563a38"
-
-[[projects]]
-  branch = "master"
-  digest = "1:13e2fa5735a82a5fb044f290cfd0dba633d1c5e516b27da0509e0dbb3515a18e"
+  digest = "1:ed860d2b2c1d066d36a89c982eefc7d019badd534f60e87ab65d3d94f0797ef0"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
     "simplelru",
   ]
   pruneopts = "NUT"
-  revision = "0fb14efe8c47ae851c0034ed7a448854d3d34cf3"
+  revision = "7f827b33c0f158ec5dfbba01bb0b14a4541fd81d"
+  version = "v0.5.3"
 
 [[projects]]
-  digest = "1:9a52adf44086cead3b384e5d0dbf7a1c1cce65e67552ee3383a8561c42a18cd3"
+  digest = "1:aaa38889f11896ee3644d77e17dc7764cc47f5f3d3b488268df2af2b52541c5f"
   name = "github.com/imdario/mergo"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "9f23e2d6bd2a77f959b2bf6acdbefd708a83a4a4"
-  version = "v0.3.6"
+  revision = "7c29201646fa3de8506f701213473dd407f19646"
+  version = "v0.3.7"
 
 [[projects]]
   digest = "1:0243cffa4a3410f161ee613dfdd903a636d07e838a42d341da95d81f42cd1d41"
@@ -144,20 +117,12 @@
   version = "1.0.1"
 
 [[projects]]
-  branch = "master"
-  digest = "1:3bf17a6e6eaa6ad24152148a631d18662f7212e21637c2699bff3369b7f00fa2"
-  name = "github.com/petar/GoLLRB"
-  packages = ["llrb"]
-  pruneopts = "NUT"
-  revision = "53be0d36a84c2a886ca057d34b6aa4468df9ccb4"
-
-[[projects]]
-  digest = "1:6c6d91dc326ed6778783cff869c49fb2f61303cdd2ebbcf90abe53505793f3b6"
-  name = "github.com/peterbourgon/diskv"
+  digest = "1:14715f705ff5dfe0ffd6571d7d201dd8e921030f8070321a79380d8ca4ec1a24"
+  name = "github.com/pkg/errors"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "5f041e8faa004a95c88a202771f4cc3e991971e6"
-  version = "v2.0.1"
+  revision = "ba968bfe8b2f7e042a574c888954fccecfa385b4"
+  version = "v0.8.1"
 
 [[projects]]
   digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
@@ -168,69 +133,84 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:998e4640c25e00ccb7b2569bf94562283937b8afb3485c0e1a0a05a15330240d"
+  digest = "1:f4aaa07a6c33f2b354726d0571acbc8ca118837c75709f6353203ae1a3f8eeab"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "8bdbc7bcc01dcbb8ec23dc8a28e332258d25251f"
-  version = "v1.4.1"
+  revision = "839c75faf7f98a33d445d181f3018b5c3409a45e"
+  version = "v1.4.2"
 
 [[projects]]
-  digest = "1:15e5c398fbd9d2c439b635a08ac161b13d04f0c2aa587fe256b65dc0c3efe8b7"
+  digest = "1:9d8420bbf131d1618bde6530af37c3799340d3762cc47210c1d9532a4c3a2779"
   name = "github.com/spf13/pflag"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "583c0c0531f06d5278b7d917446061adc344b5cd"
-  version = "v1.0.1"
+  revision = "298182f68c66c05229eb03ac171abe6e309ee79a"
+  version = "v1.0.3"
 
 [[projects]]
-  digest = "1:42e8c2456d7ec0f31e182c20022e74324c4da2cb3bd9069ff9b131fe33466308"
+  digest = "1:6e7bb8be062d38ec9e9222973e81835554bfa2181b9ab29ff206514bd44fe8d2"
   name = "github.com/stretchr/testify"
   packages = ["assert"]
   pruneopts = "NUT"
-  revision = "ffdc059bfe9ce6a4e144ba849dbedead332c6053"
-  version = "v1.3.0"
+  revision = "221dbe5ed46703ee255b1da0dec05086f5035f62"
+  version = "v1.4.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:3f3a05ae0b95893d90b9b3b5afdb79a9b3d96e4e36e099d841ae602e4aca0da8"
+  digest = "1:bbe51412d9915d64ffaa96b51d409e070665efc5194fcf145c4a27d4133107a4"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
   pruneopts = "NUT"
-  revision = "c126467f60eb25f8f27e5a981f32a87e3965053f"
+  revision = "227b76d455e791cb042b03e633e2f7fbcfdf74a5"
 
 [[projects]]
   branch = "master"
-  digest = "1:f1d86284e32b50c39145025672d1e530176c19f9fd5cd60c82c0e01da0b52f97"
+  digest = "1:34347fb8a028e8d5d32e1a52da0796fd1c3d8d4aad1ff0ade4a6e23d07b00d32"
   name = "golang.org/x/net"
   packages = [
+    "context",
+    "context/ctxhttp",
     "http/httpguts",
     "http2",
     "http2/hpack",
     "idna",
   ]
   pruneopts = "NUT"
-  revision = "afe8f62b1d6bbd81f31868121a50b06d8188e1f9"
+  revision = "24e19bdeb0f2d062d8e2640d50a7aaf2a7f80e7a"
 
 [[projects]]
   branch = "master"
-  digest = "1:43a352083eca9cd2a8e74419460d5767885501265cfca9c7204cc085aead1361"
+  digest = "1:f3a2e6d7423b8c19cdb2203cda9672900cc43012ea69f30ff6874dd453f44aec"
+  name = "golang.org/x/oauth2"
+  packages = [
+    ".",
+    "internal",
+  ]
+  pruneopts = "NUT"
+  revision = "0f29369cfe4552d0e4bcddc57cc75f4d7e672a33"
+
+[[projects]]
+  branch = "master"
+  digest = "1:8cc4634b9c72bbb85daadb12f5a3f93f320b378618e216121f632055c1fe8aa5"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = "NUT"
-  revision = "bd9dbc187b6e1dacfdd2722a87e83093c2d7bd6e"
+  revision = "bc967efca4b87fb45e946a3ea4cb891883404fd0"
 
 [[projects]]
-  digest = "1:e7071ed636b5422cc51c0e3a6cebc229d6c9fffc528814b519a980641422d619"
+  digest = "1:8d8faad6b12a3a4c819a3f9618cb6ee1fa1cfc33253abeeea8b55336721e3405"
   name = "golang.org/x/text"
   packages = [
     "collate",
     "collate/build",
     "internal/colltab",
     "internal/gen",
+    "internal/language",
+    "internal/language/compact",
     "internal/tag",
     "internal/triegen",
     "internal/ucd",
@@ -243,8 +223,8 @@
     "unicode/rangetable",
   ]
   pruneopts = "NUT"
-  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
-  version = "v0.3.0"
+  revision = "342b2e1fbaa52c93f31447ad2c6abc048c63e475"
+  version = "v0.3.2"
 
 [[projects]]
   branch = "master"
@@ -256,15 +236,40 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:1615b21484a1d35e0b3362026786b14add76026c2cfe506c49fb74393d2414c2"
+  digest = "1:efe01271c3a3eb0f9e3b7372d61b987cd90dd772ffcecc37c38f3b6a9226e2c9"
   name = "golang.org/x/tools"
   packages = [
     "go/ast/astutil",
+    "go/gcexportdata",
+    "go/internal/gcimporter",
+    "go/internal/packagesdriver",
+    "go/packages",
+    "go/types/typeutil",
     "imports",
     "internal/fastwalk",
+    "internal/gopathwalk",
+    "internal/imports",
+    "internal/module",
+    "internal/semver",
   ]
   pruneopts = "NUT"
-  revision = "25b95b48224cce18163c7d49dcfb89a2d5ecd209"
+  revision = "b0a6c2aa3ffab510cfbaab441e32f881cfe224b6"
+
+[[projects]]
+  digest = "1:372cd8eba449f9b6db06677d0e73fa193ec5b19aaee148f355503ab6127045ca"
+  name = "google.golang.org/appengine"
+  packages = [
+    "internal",
+    "internal/base",
+    "internal/datastore",
+    "internal/log",
+    "internal/remote_api",
+    "internal/urlfetch",
+    "urlfetch",
+  ]
+  pruneopts = "NUT"
+  revision = "5f2a59506353b8d5ba8cbbcd9f3c1f41f1eaf079"
+  version = "v1.6.2"
 
 [[projects]]
   digest = "1:2d1fbdc6777e5408cabeb02bf336305e724b925ff4546ded0fa8715a7267922a"
@@ -275,52 +280,59 @@
   version = "v0.9.1"
 
 [[projects]]
-  digest = "1:7c95b35057a0ff2e19f707173cc1a947fa43a6eb5c4d300d196ece0334046082"
+  digest = "1:18108594151654e9e696b27b181b953f9a90b16bf14d253dd1b397b025a1487f"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
-  version = "v2.2.1"
+  revision = "51d6538a90f86fe93ac480b35f37b2be17fef232"
+  version = "v2.2.2"
 
 [[projects]]
   branch = "release-1.1"
-  digest = "1:b3d283f539aee85a61b0cb687d85e9344696d0d4df92b909c334c64ecd82dcf9"
+  digest = "1:9555eed1984fde4a2b7b5efb89acf1f1a07a6d839062a06fd912cc77b1d544f6"
   name = "istio.io/api"
   packages = [
     "authentication/v1alpha1",
     "networking/v1alpha3",
   ]
   pruneopts = "NUT"
-  revision = "e9ab8d6a54a613b7a5877fdca1c033d5a8fbe86a"
+  revision = "162827b552e84a48f0d9d45a8f10ea1623706663"
 
 [[projects]]
-  branch = "master"
-  digest = "1:ab24c78181938293003a84bf956be09f195c57fa2f418ed6c1595f3198312f25"
+  branch = "release-1.14"
+  digest = "1:f83b66888402b9a9adf7a1154f27e5b8299e67fe1de9d1e2d4ca17562345404a"
   name = "k8s.io/api"
   packages = [
-    "admissionregistration/v1alpha1",
     "admissionregistration/v1beta1",
     "apps/v1",
     "apps/v1beta1",
     "apps/v1beta2",
+    "auditregistration/v1alpha1",
     "authentication/v1",
     "authentication/v1beta1",
     "authorization/v1",
     "authorization/v1beta1",
     "autoscaling/v1",
     "autoscaling/v2beta1",
+    "autoscaling/v2beta2",
     "batch/v1",
     "batch/v1beta1",
     "batch/v2alpha1",
     "certificates/v1beta1",
+    "coordination/v1",
+    "coordination/v1beta1",
     "core/v1",
     "events/v1beta1",
     "extensions/v1beta1",
     "networking/v1",
+    "networking/v1beta1",
+    "node/v1alpha1",
+    "node/v1beta1",
     "policy/v1beta1",
     "rbac/v1",
     "rbac/v1alpha1",
     "rbac/v1beta1",
+    "scheduling/v1",
     "scheduling/v1alpha1",
     "scheduling/v1beta1",
     "settings/v1alpha1",
@@ -329,11 +341,11 @@
     "storage/v1beta1",
   ]
   pruneopts = "NUT"
-  revision = "183f3326a9353bd6d41430fc80f96259331d029c"
+  revision = "e3a6b8045b0b303430f6d0c261fd9e35be50800e"
 
 [[projects]]
-  branch = "release-1.11"
-  digest = "1:d65cc96a7b043ac5cb753d87ff5ac43e273b210b497ce1bc0b4817852282923a"
+  branch = "release-1.14"
+  digest = "1:754bc618ffd9db9380bd8b4db61dd88e96fca6b4aaae996ad6d9972674bdf28f"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/errors",
@@ -365,6 +377,7 @@
     "pkg/util/intstr",
     "pkg/util/json",
     "pkg/util/mergepatch",
+    "pkg/util/naming",
     "pkg/util/net",
     "pkg/util/runtime",
     "pkg/util/sets",
@@ -379,11 +392,11 @@
     "third_party/forked/golang/reflect",
   ]
   pruneopts = "NUT"
-  revision = "c182ff3b98419e7305cc361fd1811988591656cf"
+  revision = "a9f1d8a9c10182d101acf19b5145c3d4e9299adb"
 
 [[projects]]
-  branch = "release-8.0"
-  digest = "1:7e5ce2ced50556773b29fde1ca1fd181707503cde7c501893d308281b45f510b"
+  branch = "release-11.0"
+  digest = "1:0246fe36c3f0bfeb140983438d81f558dbd3c3b3f2071209cf4651461fd83cb3"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -406,20 +419,19 @@
     "tools/metrics",
     "tools/pager",
     "transport",
-    "util/buffer",
     "util/cert",
     "util/connrotation",
     "util/flowcontrol",
     "util/homedir",
-    "util/integer",
+    "util/keyutil",
     "util/retry",
   ]
   pruneopts = "NUT"
-  revision = "4022682532b3b46b46a31b4c6150cbf55174cf0f"
+  revision = "6d55c1b1f1ca8ad83d572bbc3ca55ba5526d9d71"
 
 [[projects]]
-  branch = "release-1.11"
-  digest = "1:332f5b5962cb4766ee8db261b948ec6c27a79a0006f1c638b4cbb4a203069aaf"
+  branch = "release-1.14"
+  digest = "1:0ca40cba3558ea765d0e7fa91ebd32d661909d5c331c49c2a271af66f0b5604d"
   name = "k8s.io/code-generator"
   packages = [
     "cmd/client-gen",
@@ -430,14 +442,15 @@
     "cmd/client-gen/generators/util",
     "cmd/client-gen/path",
     "cmd/client-gen/types",
+    "pkg/namer",
     "pkg/util",
   ]
   pruneopts = ""
-  revision = "f8cba74510f397bac80157a6c4ccb0ffbc31b9d0"
+  revision = "6c2a4329ac290d921e8616cad41635c87dbb1518"
 
 [[projects]]
   branch = "master"
-  digest = "1:d1e2c209e5b2a0fee08e687a43e63f81767817b7dd8a42af7667e5d58bf6844a"
+  digest = "1:a8c60fdc825be548a5cd9f599565d2c0dceff8d77a2b5ea00ff891e4aca33de5"
   name = "k8s.io/gengo"
   packages = [
     "args",
@@ -447,7 +460,15 @@
     "types",
   ]
   pruneopts = ""
-  revision = "f659ec9d5207b3bf034eb9b7e22720d360d28712"
+  revision = "ebc107f98eab922ef99d645781b87caca01f4f48"
+
+[[projects]]
+  digest = "1:c05ad592787fc6cdacf8c5309d826561aa4a7d9e4e7ea28660dfb2c77ff68ab0"
+  name = "k8s.io/klog"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "3ca30a56d8a775276f9cdae009ba326fdc05af7f"
+  version = "v0.4.0"
 
 [[projects]]
   branch = "master"
@@ -455,7 +476,27 @@
   name = "k8s.io/kube-openapi"
   packages = ["pkg/util/proto"]
   pruneopts = "NUT"
-  revision = "94e1e7b7574c44c4c0f2007de6fe617e259191f3"
+  revision = "743ec37842bffe49dd4221d9026f30fb1d5adbc4"
+
+[[projects]]
+  branch = "master"
+  digest = "1:2d3f59daa4b479ff4e100a2e1d8fea6780040fdadc177869531fe4cc29407f55"
+  name = "k8s.io/utils"
+  packages = [
+    "buffer",
+    "integer",
+    "trace",
+  ]
+  pruneopts = "NUT"
+  revision = "3d4f5b7dea0b7c63c77d7fb1f0ee433ad8d54667"
+
+[[projects]]
+  digest = "1:8730e0150dfb2b7e173890c8b9868e7a273082ef8e39f4940e3506a481cf895c"
+  name = "sigs.k8s.io/yaml"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "fd68e9863619f6ec2fdd8625fe1f02e7c877e480"
+  version = "v1.1.0"
 
 [solve-meta]
   analyzer-name = "dep"
@@ -475,6 +516,7 @@
     "k8s.io/apimachinery/pkg/runtime/schema",
     "k8s.io/apimachinery/pkg/runtime/serializer",
     "k8s.io/apimachinery/pkg/types",
+    "k8s.io/apimachinery/pkg/util/runtime",
     "k8s.io/apimachinery/pkg/watch",
     "k8s.io/client-go/discovery",
     "k8s.io/client-go/discovery/fake",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -37,11 +37,15 @@ required = [
 # https://github.com/kubernetes/code-generator/issues/6
 [[constraint]]
   name = "k8s.io/code-generator"
-  branch = "release-1.11"
+  branch = "release-1.14"
 
 [[constraint]]
   name = "k8s.io/apimachinery"
-  branch = "release-1.11"
+  branch = "release-1.14"
+
+[[override]]
+  name = "k8s.io/api"
+  branch = "release-1.14"
 
 # FIXME: Following https://github.com/kubernetes/apimachinery/issues/46 to get around 
 #   unknown field 'CaseSensitive' in struct literal error when bringing in apimachinery 1.11
@@ -55,7 +59,7 @@ required = [
 
 [[constraint]]
   name = "k8s.io/client-go"
-  branch = "release-8.0"
+  branch = "release-11.0"
 
 [prune]
   non-go = true

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -37,15 +37,15 @@ required = [
 # https://github.com/kubernetes/code-generator/issues/6
 [[constraint]]
   name = "k8s.io/code-generator"
-  branch = "release-1.14"
+  branch = "release-1.13"
 
 [[constraint]]
   name = "k8s.io/apimachinery"
-  branch = "release-1.14"
+  branch = "release-1.13"
 
 [[override]]
   name = "k8s.io/api"
-  branch = "release-1.14"
+  branch = "release-1.13"
 
 # FIXME: Following https://github.com/kubernetes/apimachinery/issues/46 to get around 
 #   unknown field 'CaseSensitive' in struct literal error when bringing in apimachinery 1.11
@@ -59,7 +59,7 @@ required = [
 
 [[constraint]]
   name = "k8s.io/client-go"
-  branch = "release-11.0"
+  branch = "release-10.0"
 
 [prune]
   non-go = true

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -26,15 +26,15 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
 var scheme = runtime.NewScheme()
 var codecs = serializer.NewCodecFactory(scheme)
 var parameterCodec = runtime.NewParameterCodec(scheme)
-
-func init() {
-	v1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})
-	AddToScheme(scheme)
+var localSchemeBuilder = runtime.SchemeBuilder{
+	authenticationv1alpha1.AddToScheme,
+	networkingv1alpha3.AddToScheme,
 }
 
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
@@ -47,11 +47,13 @@ func init() {
 //   )
 //
 //   kclientset, _ := kubernetes.NewForConfig(c)
-//   aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.
-func AddToScheme(scheme *runtime.Scheme) {
-	authenticationv1alpha1.AddToScheme(scheme)
-	networkingv1alpha3.AddToScheme(scheme)
+var AddToScheme = localSchemeBuilder.AddToScheme
+
+func init() {
+	v1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})
+	utilruntime.Must(AddToScheme(scheme))
 }

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -26,15 +26,15 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
 var Scheme = runtime.NewScheme()
 var Codecs = serializer.NewCodecFactory(Scheme)
 var ParameterCodec = runtime.NewParameterCodec(Scheme)
-
-func init() {
-	v1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
-	AddToScheme(Scheme)
+var localSchemeBuilder = runtime.SchemeBuilder{
+	authenticationv1alpha1.AddToScheme,
+	networkingv1alpha3.AddToScheme,
 }
 
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
@@ -47,11 +47,13 @@ func init() {
 //   )
 //
 //   kclientset, _ := kubernetes.NewForConfig(c)
-//   aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.
-func AddToScheme(scheme *runtime.Scheme) {
-	authenticationv1alpha1.AddToScheme(scheme)
-	networkingv1alpha3.AddToScheme(scheme)
+var AddToScheme = localSchemeBuilder.AddToScheme
+
+func init() {
+	v1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
+	utilruntime.Must(AddToScheme(Scheme))
 }

--- a/pkg/client/clientset/versioned/typed/authentication/v1alpha1/fake/fake_meshpolicy.go
+++ b/pkg/client/clientset/versioned/typed/authentication/v1alpha1/fake/fake_meshpolicy.go
@@ -113,7 +113,7 @@ func (c *FakeMeshPolicies) DeleteCollection(options *v1.DeleteOptions, listOptio
 // Patch applies the patch and returns the patched meshPolicy.
 func (c *FakeMeshPolicies) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.MeshPolicy, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(meshpoliciesResource, name, data, subresources...), &v1alpha1.MeshPolicy{})
+		Invokes(testing.NewRootPatchSubresourceAction(meshpoliciesResource, name, pt, data, subresources...), &v1alpha1.MeshPolicy{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/clientset/versioned/typed/authentication/v1alpha1/fake/fake_policy.go
+++ b/pkg/client/clientset/versioned/typed/authentication/v1alpha1/fake/fake_policy.go
@@ -120,7 +120,7 @@ func (c *FakePolicies) DeleteCollection(options *v1.DeleteOptions, listOptions v
 // Patch applies the patch and returns the patched policy.
 func (c *FakePolicies) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.Policy, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(policiesResource, c.ns, name, data, subresources...), &v1alpha1.Policy{})
+		Invokes(testing.NewPatchSubresourceAction(policiesResource, c.ns, name, pt, data, subresources...), &v1alpha1.Policy{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset/versioned/typed/authentication/v1alpha1/meshpolicy.go
+++ b/pkg/client/clientset/versioned/typed/authentication/v1alpha1/meshpolicy.go
@@ -20,6 +20,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"time"
+
 	v1alpha1 "github.com/aspenmesh/istio-client-go/pkg/apis/authentication/v1alpha1"
 	scheme "github.com/aspenmesh/istio-client-go/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -73,10 +75,15 @@ func (c *meshPolicies) Get(name string, options v1.GetOptions) (result *v1alpha1
 
 // List takes label and field selectors, and returns the list of MeshPolicies that match those selectors.
 func (c *meshPolicies) List(opts v1.ListOptions) (result *v1alpha1.MeshPolicyList, err error) {
+	var timeout time.Duration
+	if opts.TimeoutSeconds != nil {
+		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
+	}
 	result = &v1alpha1.MeshPolicyList{}
 	err = c.client.Get().
 		Resource("meshpolicies").
 		VersionedParams(&opts, scheme.ParameterCodec).
+		Timeout(timeout).
 		Do().
 		Into(result)
 	return
@@ -84,10 +91,15 @@ func (c *meshPolicies) List(opts v1.ListOptions) (result *v1alpha1.MeshPolicyLis
 
 // Watch returns a watch.Interface that watches the requested meshPolicies.
 func (c *meshPolicies) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	var timeout time.Duration
+	if opts.TimeoutSeconds != nil {
+		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
+	}
 	opts.Watch = true
 	return c.client.Get().
 		Resource("meshpolicies").
 		VersionedParams(&opts, scheme.ParameterCodec).
+		Timeout(timeout).
 		Watch()
 }
 
@@ -126,9 +138,14 @@ func (c *meshPolicies) Delete(name string, options *v1.DeleteOptions) error {
 
 // DeleteCollection deletes a collection of objects.
 func (c *meshPolicies) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	var timeout time.Duration
+	if listOptions.TimeoutSeconds != nil {
+		timeout = time.Duration(*listOptions.TimeoutSeconds) * time.Second
+	}
 	return c.client.Delete().
 		Resource("meshpolicies").
 		VersionedParams(&listOptions, scheme.ParameterCodec).
+		Timeout(timeout).
 		Body(options).
 		Do().
 		Error()

--- a/pkg/client/clientset/versioned/typed/authentication/v1alpha1/policy.go
+++ b/pkg/client/clientset/versioned/typed/authentication/v1alpha1/policy.go
@@ -20,6 +20,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"time"
+
 	v1alpha1 "github.com/aspenmesh/istio-client-go/pkg/apis/authentication/v1alpha1"
 	scheme "github.com/aspenmesh/istio-client-go/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -76,11 +78,16 @@ func (c *policies) Get(name string, options v1.GetOptions) (result *v1alpha1.Pol
 
 // List takes label and field selectors, and returns the list of Policies that match those selectors.
 func (c *policies) List(opts v1.ListOptions) (result *v1alpha1.PolicyList, err error) {
+	var timeout time.Duration
+	if opts.TimeoutSeconds != nil {
+		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
+	}
 	result = &v1alpha1.PolicyList{}
 	err = c.client.Get().
 		Namespace(c.ns).
 		Resource("policies").
 		VersionedParams(&opts, scheme.ParameterCodec).
+		Timeout(timeout).
 		Do().
 		Into(result)
 	return
@@ -88,11 +95,16 @@ func (c *policies) List(opts v1.ListOptions) (result *v1alpha1.PolicyList, err e
 
 // Watch returns a watch.Interface that watches the requested policies.
 func (c *policies) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	var timeout time.Duration
+	if opts.TimeoutSeconds != nil {
+		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
+	}
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
 		Resource("policies").
 		VersionedParams(&opts, scheme.ParameterCodec).
+		Timeout(timeout).
 		Watch()
 }
 
@@ -134,10 +146,15 @@ func (c *policies) Delete(name string, options *v1.DeleteOptions) error {
 
 // DeleteCollection deletes a collection of objects.
 func (c *policies) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	var timeout time.Duration
+	if listOptions.TimeoutSeconds != nil {
+		timeout = time.Duration(*listOptions.TimeoutSeconds) * time.Second
+	}
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("policies").
 		VersionedParams(&listOptions, scheme.ParameterCodec).
+		Timeout(timeout).
 		Body(options).
 		Do().
 		Error()

--- a/pkg/client/clientset/versioned/typed/networking/v1alpha3/destinationrule.go
+++ b/pkg/client/clientset/versioned/typed/networking/v1alpha3/destinationrule.go
@@ -20,6 +20,8 @@ limitations under the License.
 package v1alpha3
 
 import (
+	"time"
+
 	v1alpha3 "github.com/aspenmesh/istio-client-go/pkg/apis/networking/v1alpha3"
 	scheme "github.com/aspenmesh/istio-client-go/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -76,11 +78,16 @@ func (c *destinationRules) Get(name string, options v1.GetOptions) (result *v1al
 
 // List takes label and field selectors, and returns the list of DestinationRules that match those selectors.
 func (c *destinationRules) List(opts v1.ListOptions) (result *v1alpha3.DestinationRuleList, err error) {
+	var timeout time.Duration
+	if opts.TimeoutSeconds != nil {
+		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
+	}
 	result = &v1alpha3.DestinationRuleList{}
 	err = c.client.Get().
 		Namespace(c.ns).
 		Resource("destinationrules").
 		VersionedParams(&opts, scheme.ParameterCodec).
+		Timeout(timeout).
 		Do().
 		Into(result)
 	return
@@ -88,11 +95,16 @@ func (c *destinationRules) List(opts v1.ListOptions) (result *v1alpha3.Destinati
 
 // Watch returns a watch.Interface that watches the requested destinationRules.
 func (c *destinationRules) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	var timeout time.Duration
+	if opts.TimeoutSeconds != nil {
+		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
+	}
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
 		Resource("destinationrules").
 		VersionedParams(&opts, scheme.ParameterCodec).
+		Timeout(timeout).
 		Watch()
 }
 
@@ -134,10 +146,15 @@ func (c *destinationRules) Delete(name string, options *v1.DeleteOptions) error 
 
 // DeleteCollection deletes a collection of objects.
 func (c *destinationRules) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	var timeout time.Duration
+	if listOptions.TimeoutSeconds != nil {
+		timeout = time.Duration(*listOptions.TimeoutSeconds) * time.Second
+	}
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("destinationrules").
 		VersionedParams(&listOptions, scheme.ParameterCodec).
+		Timeout(timeout).
 		Body(options).
 		Do().
 		Error()

--- a/pkg/client/clientset/versioned/typed/networking/v1alpha3/envoyfilter.go
+++ b/pkg/client/clientset/versioned/typed/networking/v1alpha3/envoyfilter.go
@@ -20,6 +20,8 @@ limitations under the License.
 package v1alpha3
 
 import (
+	"time"
+
 	v1alpha3 "github.com/aspenmesh/istio-client-go/pkg/apis/networking/v1alpha3"
 	scheme "github.com/aspenmesh/istio-client-go/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -76,11 +78,16 @@ func (c *envoyFilters) Get(name string, options v1.GetOptions) (result *v1alpha3
 
 // List takes label and field selectors, and returns the list of EnvoyFilters that match those selectors.
 func (c *envoyFilters) List(opts v1.ListOptions) (result *v1alpha3.EnvoyFilterList, err error) {
+	var timeout time.Duration
+	if opts.TimeoutSeconds != nil {
+		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
+	}
 	result = &v1alpha3.EnvoyFilterList{}
 	err = c.client.Get().
 		Namespace(c.ns).
 		Resource("envoyfilters").
 		VersionedParams(&opts, scheme.ParameterCodec).
+		Timeout(timeout).
 		Do().
 		Into(result)
 	return
@@ -88,11 +95,16 @@ func (c *envoyFilters) List(opts v1.ListOptions) (result *v1alpha3.EnvoyFilterLi
 
 // Watch returns a watch.Interface that watches the requested envoyFilters.
 func (c *envoyFilters) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	var timeout time.Duration
+	if opts.TimeoutSeconds != nil {
+		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
+	}
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
 		Resource("envoyfilters").
 		VersionedParams(&opts, scheme.ParameterCodec).
+		Timeout(timeout).
 		Watch()
 }
 
@@ -134,10 +146,15 @@ func (c *envoyFilters) Delete(name string, options *v1.DeleteOptions) error {
 
 // DeleteCollection deletes a collection of objects.
 func (c *envoyFilters) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	var timeout time.Duration
+	if listOptions.TimeoutSeconds != nil {
+		timeout = time.Duration(*listOptions.TimeoutSeconds) * time.Second
+	}
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("envoyfilters").
 		VersionedParams(&listOptions, scheme.ParameterCodec).
+		Timeout(timeout).
 		Body(options).
 		Do().
 		Error()

--- a/pkg/client/clientset/versioned/typed/networking/v1alpha3/fake/fake_destinationrule.go
+++ b/pkg/client/clientset/versioned/typed/networking/v1alpha3/fake/fake_destinationrule.go
@@ -120,7 +120,7 @@ func (c *FakeDestinationRules) DeleteCollection(options *v1.DeleteOptions, listO
 // Patch applies the patch and returns the patched destinationRule.
 func (c *FakeDestinationRules) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha3.DestinationRule, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(destinationrulesResource, c.ns, name, data, subresources...), &v1alpha3.DestinationRule{})
+		Invokes(testing.NewPatchSubresourceAction(destinationrulesResource, c.ns, name, pt, data, subresources...), &v1alpha3.DestinationRule{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset/versioned/typed/networking/v1alpha3/fake/fake_envoyfilter.go
+++ b/pkg/client/clientset/versioned/typed/networking/v1alpha3/fake/fake_envoyfilter.go
@@ -120,7 +120,7 @@ func (c *FakeEnvoyFilters) DeleteCollection(options *v1.DeleteOptions, listOptio
 // Patch applies the patch and returns the patched envoyFilter.
 func (c *FakeEnvoyFilters) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha3.EnvoyFilter, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(envoyfiltersResource, c.ns, name, data, subresources...), &v1alpha3.EnvoyFilter{})
+		Invokes(testing.NewPatchSubresourceAction(envoyfiltersResource, c.ns, name, pt, data, subresources...), &v1alpha3.EnvoyFilter{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset/versioned/typed/networking/v1alpha3/fake/fake_gateway.go
+++ b/pkg/client/clientset/versioned/typed/networking/v1alpha3/fake/fake_gateway.go
@@ -120,7 +120,7 @@ func (c *FakeGateways) DeleteCollection(options *v1.DeleteOptions, listOptions v
 // Patch applies the patch and returns the patched gateway.
 func (c *FakeGateways) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha3.Gateway, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(gatewaysResource, c.ns, name, data, subresources...), &v1alpha3.Gateway{})
+		Invokes(testing.NewPatchSubresourceAction(gatewaysResource, c.ns, name, pt, data, subresources...), &v1alpha3.Gateway{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset/versioned/typed/networking/v1alpha3/fake/fake_serviceentry.go
+++ b/pkg/client/clientset/versioned/typed/networking/v1alpha3/fake/fake_serviceentry.go
@@ -120,7 +120,7 @@ func (c *FakeServiceEntries) DeleteCollection(options *v1.DeleteOptions, listOpt
 // Patch applies the patch and returns the patched serviceEntry.
 func (c *FakeServiceEntries) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha3.ServiceEntry, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(serviceentriesResource, c.ns, name, data, subresources...), &v1alpha3.ServiceEntry{})
+		Invokes(testing.NewPatchSubresourceAction(serviceentriesResource, c.ns, name, pt, data, subresources...), &v1alpha3.ServiceEntry{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset/versioned/typed/networking/v1alpha3/fake/fake_virtualservice.go
+++ b/pkg/client/clientset/versioned/typed/networking/v1alpha3/fake/fake_virtualservice.go
@@ -120,7 +120,7 @@ func (c *FakeVirtualServices) DeleteCollection(options *v1.DeleteOptions, listOp
 // Patch applies the patch and returns the patched virtualService.
 func (c *FakeVirtualServices) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha3.VirtualService, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(virtualservicesResource, c.ns, name, data, subresources...), &v1alpha3.VirtualService{})
+		Invokes(testing.NewPatchSubresourceAction(virtualservicesResource, c.ns, name, pt, data, subresources...), &v1alpha3.VirtualService{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/clientset/versioned/typed/networking/v1alpha3/gateway.go
+++ b/pkg/client/clientset/versioned/typed/networking/v1alpha3/gateway.go
@@ -20,6 +20,8 @@ limitations under the License.
 package v1alpha3
 
 import (
+	"time"
+
 	v1alpha3 "github.com/aspenmesh/istio-client-go/pkg/apis/networking/v1alpha3"
 	scheme "github.com/aspenmesh/istio-client-go/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -76,11 +78,16 @@ func (c *gateways) Get(name string, options v1.GetOptions) (result *v1alpha3.Gat
 
 // List takes label and field selectors, and returns the list of Gateways that match those selectors.
 func (c *gateways) List(opts v1.ListOptions) (result *v1alpha3.GatewayList, err error) {
+	var timeout time.Duration
+	if opts.TimeoutSeconds != nil {
+		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
+	}
 	result = &v1alpha3.GatewayList{}
 	err = c.client.Get().
 		Namespace(c.ns).
 		Resource("gateways").
 		VersionedParams(&opts, scheme.ParameterCodec).
+		Timeout(timeout).
 		Do().
 		Into(result)
 	return
@@ -88,11 +95,16 @@ func (c *gateways) List(opts v1.ListOptions) (result *v1alpha3.GatewayList, err 
 
 // Watch returns a watch.Interface that watches the requested gateways.
 func (c *gateways) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	var timeout time.Duration
+	if opts.TimeoutSeconds != nil {
+		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
+	}
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
 		Resource("gateways").
 		VersionedParams(&opts, scheme.ParameterCodec).
+		Timeout(timeout).
 		Watch()
 }
 
@@ -134,10 +146,15 @@ func (c *gateways) Delete(name string, options *v1.DeleteOptions) error {
 
 // DeleteCollection deletes a collection of objects.
 func (c *gateways) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	var timeout time.Duration
+	if listOptions.TimeoutSeconds != nil {
+		timeout = time.Duration(*listOptions.TimeoutSeconds) * time.Second
+	}
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("gateways").
 		VersionedParams(&listOptions, scheme.ParameterCodec).
+		Timeout(timeout).
 		Body(options).
 		Do().
 		Error()

--- a/pkg/client/clientset/versioned/typed/networking/v1alpha3/serviceentry.go
+++ b/pkg/client/clientset/versioned/typed/networking/v1alpha3/serviceentry.go
@@ -20,6 +20,8 @@ limitations under the License.
 package v1alpha3
 
 import (
+	"time"
+
 	v1alpha3 "github.com/aspenmesh/istio-client-go/pkg/apis/networking/v1alpha3"
 	scheme "github.com/aspenmesh/istio-client-go/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -76,11 +78,16 @@ func (c *serviceEntries) Get(name string, options v1.GetOptions) (result *v1alph
 
 // List takes label and field selectors, and returns the list of ServiceEntries that match those selectors.
 func (c *serviceEntries) List(opts v1.ListOptions) (result *v1alpha3.ServiceEntryList, err error) {
+	var timeout time.Duration
+	if opts.TimeoutSeconds != nil {
+		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
+	}
 	result = &v1alpha3.ServiceEntryList{}
 	err = c.client.Get().
 		Namespace(c.ns).
 		Resource("serviceentries").
 		VersionedParams(&opts, scheme.ParameterCodec).
+		Timeout(timeout).
 		Do().
 		Into(result)
 	return
@@ -88,11 +95,16 @@ func (c *serviceEntries) List(opts v1.ListOptions) (result *v1alpha3.ServiceEntr
 
 // Watch returns a watch.Interface that watches the requested serviceEntries.
 func (c *serviceEntries) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	var timeout time.Duration
+	if opts.TimeoutSeconds != nil {
+		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
+	}
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
 		Resource("serviceentries").
 		VersionedParams(&opts, scheme.ParameterCodec).
+		Timeout(timeout).
 		Watch()
 }
 
@@ -134,10 +146,15 @@ func (c *serviceEntries) Delete(name string, options *v1.DeleteOptions) error {
 
 // DeleteCollection deletes a collection of objects.
 func (c *serviceEntries) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	var timeout time.Duration
+	if listOptions.TimeoutSeconds != nil {
+		timeout = time.Duration(*listOptions.TimeoutSeconds) * time.Second
+	}
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("serviceentries").
 		VersionedParams(&listOptions, scheme.ParameterCodec).
+		Timeout(timeout).
 		Body(options).
 		Do().
 		Error()

--- a/pkg/client/clientset/versioned/typed/networking/v1alpha3/virtualservice.go
+++ b/pkg/client/clientset/versioned/typed/networking/v1alpha3/virtualservice.go
@@ -20,6 +20,8 @@ limitations under the License.
 package v1alpha3
 
 import (
+	"time"
+
 	v1alpha3 "github.com/aspenmesh/istio-client-go/pkg/apis/networking/v1alpha3"
 	scheme "github.com/aspenmesh/istio-client-go/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -76,11 +78,16 @@ func (c *virtualServices) Get(name string, options v1.GetOptions) (result *v1alp
 
 // List takes label and field selectors, and returns the list of VirtualServices that match those selectors.
 func (c *virtualServices) List(opts v1.ListOptions) (result *v1alpha3.VirtualServiceList, err error) {
+	var timeout time.Duration
+	if opts.TimeoutSeconds != nil {
+		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
+	}
 	result = &v1alpha3.VirtualServiceList{}
 	err = c.client.Get().
 		Namespace(c.ns).
 		Resource("virtualservices").
 		VersionedParams(&opts, scheme.ParameterCodec).
+		Timeout(timeout).
 		Do().
 		Into(result)
 	return
@@ -88,11 +95,16 @@ func (c *virtualServices) List(opts v1.ListOptions) (result *v1alpha3.VirtualSer
 
 // Watch returns a watch.Interface that watches the requested virtualServices.
 func (c *virtualServices) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	var timeout time.Duration
+	if opts.TimeoutSeconds != nil {
+		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
+	}
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
 		Resource("virtualservices").
 		VersionedParams(&opts, scheme.ParameterCodec).
+		Timeout(timeout).
 		Watch()
 }
 
@@ -134,10 +146,15 @@ func (c *virtualServices) Delete(name string, options *v1.DeleteOptions) error {
 
 // DeleteCollection deletes a collection of objects.
 func (c *virtualServices) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	var timeout time.Duration
+	if listOptions.TimeoutSeconds != nil {
+		timeout = time.Duration(*listOptions.TimeoutSeconds) * time.Second
+	}
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("virtualservices").
 		VersionedParams(&listOptions, scheme.ParameterCodec).
+		Timeout(timeout).
 		Body(options).
 		Do().
 		Error()

--- a/pkg/client/informers/externalversions/authentication/v1alpha1/meshpolicy.go
+++ b/pkg/client/informers/externalversions/authentication/v1alpha1/meshpolicy.go
@@ -22,7 +22,7 @@ package v1alpha1
 import (
 	time "time"
 
-	authentication_v1alpha1 "github.com/aspenmesh/istio-client-go/pkg/apis/authentication/v1alpha1"
+	authenticationv1alpha1 "github.com/aspenmesh/istio-client-go/pkg/apis/authentication/v1alpha1"
 	versioned "github.com/aspenmesh/istio-client-go/pkg/client/clientset/versioned"
 	internalinterfaces "github.com/aspenmesh/istio-client-go/pkg/client/informers/externalversions/internalinterfaces"
 	v1alpha1 "github.com/aspenmesh/istio-client-go/pkg/client/listers/authentication/v1alpha1"
@@ -70,7 +70,7 @@ func NewFilteredMeshPolicyInformer(client versioned.Interface, resyncPeriod time
 				return client.AuthenticationV1alpha1().MeshPolicies().Watch(options)
 			},
 		},
-		&authentication_v1alpha1.MeshPolicy{},
+		&authenticationv1alpha1.MeshPolicy{},
 		resyncPeriod,
 		indexers,
 	)
@@ -81,7 +81,7 @@ func (f *meshPolicyInformer) defaultInformer(client versioned.Interface, resyncP
 }
 
 func (f *meshPolicyInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&authentication_v1alpha1.MeshPolicy{}, f.defaultInformer)
+	return f.factory.InformerFor(&authenticationv1alpha1.MeshPolicy{}, f.defaultInformer)
 }
 
 func (f *meshPolicyInformer) Lister() v1alpha1.MeshPolicyLister {

--- a/pkg/client/informers/externalversions/authentication/v1alpha1/policy.go
+++ b/pkg/client/informers/externalversions/authentication/v1alpha1/policy.go
@@ -22,7 +22,7 @@ package v1alpha1
 import (
 	time "time"
 
-	authentication_v1alpha1 "github.com/aspenmesh/istio-client-go/pkg/apis/authentication/v1alpha1"
+	authenticationv1alpha1 "github.com/aspenmesh/istio-client-go/pkg/apis/authentication/v1alpha1"
 	versioned "github.com/aspenmesh/istio-client-go/pkg/client/clientset/versioned"
 	internalinterfaces "github.com/aspenmesh/istio-client-go/pkg/client/informers/externalversions/internalinterfaces"
 	v1alpha1 "github.com/aspenmesh/istio-client-go/pkg/client/listers/authentication/v1alpha1"
@@ -71,7 +71,7 @@ func NewFilteredPolicyInformer(client versioned.Interface, namespace string, res
 				return client.AuthenticationV1alpha1().Policies(namespace).Watch(options)
 			},
 		},
-		&authentication_v1alpha1.Policy{},
+		&authenticationv1alpha1.Policy{},
 		resyncPeriod,
 		indexers,
 	)
@@ -82,7 +82,7 @@ func (f *policyInformer) defaultInformer(client versioned.Interface, resyncPerio
 }
 
 func (f *policyInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&authentication_v1alpha1.Policy{}, f.defaultInformer)
+	return f.factory.InformerFor(&authenticationv1alpha1.Policy{}, f.defaultInformer)
 }
 
 func (f *policyInformer) Lister() v1alpha1.PolicyLister {

--- a/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -28,6 +28,7 @@ import (
 	cache "k8s.io/client-go/tools/cache"
 )
 
+// NewInformerFunc takes versioned.Interface and time.Duration to return a SharedIndexInformer.
 type NewInformerFunc func(versioned.Interface, time.Duration) cache.SharedIndexInformer
 
 // SharedInformerFactory a small interface to allow for adding an informer without an import cycle
@@ -36,4 +37,5 @@ type SharedInformerFactory interface {
 	InformerFor(obj runtime.Object, newFunc NewInformerFunc) cache.SharedIndexInformer
 }
 
+// TweakListOptionsFunc is a function that transforms a v1.ListOptions.
 type TweakListOptionsFunc func(*v1.ListOptions)

--- a/pkg/client/informers/externalversions/networking/v1alpha3/destinationrule.go
+++ b/pkg/client/informers/externalversions/networking/v1alpha3/destinationrule.go
@@ -22,7 +22,7 @@ package v1alpha3
 import (
 	time "time"
 
-	networking_v1alpha3 "github.com/aspenmesh/istio-client-go/pkg/apis/networking/v1alpha3"
+	networkingv1alpha3 "github.com/aspenmesh/istio-client-go/pkg/apis/networking/v1alpha3"
 	versioned "github.com/aspenmesh/istio-client-go/pkg/client/clientset/versioned"
 	internalinterfaces "github.com/aspenmesh/istio-client-go/pkg/client/informers/externalversions/internalinterfaces"
 	v1alpha3 "github.com/aspenmesh/istio-client-go/pkg/client/listers/networking/v1alpha3"
@@ -71,7 +71,7 @@ func NewFilteredDestinationRuleInformer(client versioned.Interface, namespace st
 				return client.NetworkingV1alpha3().DestinationRules(namespace).Watch(options)
 			},
 		},
-		&networking_v1alpha3.DestinationRule{},
+		&networkingv1alpha3.DestinationRule{},
 		resyncPeriod,
 		indexers,
 	)
@@ -82,7 +82,7 @@ func (f *destinationRuleInformer) defaultInformer(client versioned.Interface, re
 }
 
 func (f *destinationRuleInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&networking_v1alpha3.DestinationRule{}, f.defaultInformer)
+	return f.factory.InformerFor(&networkingv1alpha3.DestinationRule{}, f.defaultInformer)
 }
 
 func (f *destinationRuleInformer) Lister() v1alpha3.DestinationRuleLister {

--- a/pkg/client/informers/externalversions/networking/v1alpha3/envoyfilter.go
+++ b/pkg/client/informers/externalversions/networking/v1alpha3/envoyfilter.go
@@ -22,7 +22,7 @@ package v1alpha3
 import (
 	time "time"
 
-	networking_v1alpha3 "github.com/aspenmesh/istio-client-go/pkg/apis/networking/v1alpha3"
+	networkingv1alpha3 "github.com/aspenmesh/istio-client-go/pkg/apis/networking/v1alpha3"
 	versioned "github.com/aspenmesh/istio-client-go/pkg/client/clientset/versioned"
 	internalinterfaces "github.com/aspenmesh/istio-client-go/pkg/client/informers/externalversions/internalinterfaces"
 	v1alpha3 "github.com/aspenmesh/istio-client-go/pkg/client/listers/networking/v1alpha3"
@@ -71,7 +71,7 @@ func NewFilteredEnvoyFilterInformer(client versioned.Interface, namespace string
 				return client.NetworkingV1alpha3().EnvoyFilters(namespace).Watch(options)
 			},
 		},
-		&networking_v1alpha3.EnvoyFilter{},
+		&networkingv1alpha3.EnvoyFilter{},
 		resyncPeriod,
 		indexers,
 	)
@@ -82,7 +82,7 @@ func (f *envoyFilterInformer) defaultInformer(client versioned.Interface, resync
 }
 
 func (f *envoyFilterInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&networking_v1alpha3.EnvoyFilter{}, f.defaultInformer)
+	return f.factory.InformerFor(&networkingv1alpha3.EnvoyFilter{}, f.defaultInformer)
 }
 
 func (f *envoyFilterInformer) Lister() v1alpha3.EnvoyFilterLister {

--- a/pkg/client/informers/externalversions/networking/v1alpha3/gateway.go
+++ b/pkg/client/informers/externalversions/networking/v1alpha3/gateway.go
@@ -22,7 +22,7 @@ package v1alpha3
 import (
 	time "time"
 
-	networking_v1alpha3 "github.com/aspenmesh/istio-client-go/pkg/apis/networking/v1alpha3"
+	networkingv1alpha3 "github.com/aspenmesh/istio-client-go/pkg/apis/networking/v1alpha3"
 	versioned "github.com/aspenmesh/istio-client-go/pkg/client/clientset/versioned"
 	internalinterfaces "github.com/aspenmesh/istio-client-go/pkg/client/informers/externalversions/internalinterfaces"
 	v1alpha3 "github.com/aspenmesh/istio-client-go/pkg/client/listers/networking/v1alpha3"
@@ -71,7 +71,7 @@ func NewFilteredGatewayInformer(client versioned.Interface, namespace string, re
 				return client.NetworkingV1alpha3().Gateways(namespace).Watch(options)
 			},
 		},
-		&networking_v1alpha3.Gateway{},
+		&networkingv1alpha3.Gateway{},
 		resyncPeriod,
 		indexers,
 	)
@@ -82,7 +82,7 @@ func (f *gatewayInformer) defaultInformer(client versioned.Interface, resyncPeri
 }
 
 func (f *gatewayInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&networking_v1alpha3.Gateway{}, f.defaultInformer)
+	return f.factory.InformerFor(&networkingv1alpha3.Gateway{}, f.defaultInformer)
 }
 
 func (f *gatewayInformer) Lister() v1alpha3.GatewayLister {

--- a/pkg/client/informers/externalversions/networking/v1alpha3/serviceentry.go
+++ b/pkg/client/informers/externalversions/networking/v1alpha3/serviceentry.go
@@ -22,7 +22,7 @@ package v1alpha3
 import (
 	time "time"
 
-	networking_v1alpha3 "github.com/aspenmesh/istio-client-go/pkg/apis/networking/v1alpha3"
+	networkingv1alpha3 "github.com/aspenmesh/istio-client-go/pkg/apis/networking/v1alpha3"
 	versioned "github.com/aspenmesh/istio-client-go/pkg/client/clientset/versioned"
 	internalinterfaces "github.com/aspenmesh/istio-client-go/pkg/client/informers/externalversions/internalinterfaces"
 	v1alpha3 "github.com/aspenmesh/istio-client-go/pkg/client/listers/networking/v1alpha3"
@@ -71,7 +71,7 @@ func NewFilteredServiceEntryInformer(client versioned.Interface, namespace strin
 				return client.NetworkingV1alpha3().ServiceEntries(namespace).Watch(options)
 			},
 		},
-		&networking_v1alpha3.ServiceEntry{},
+		&networkingv1alpha3.ServiceEntry{},
 		resyncPeriod,
 		indexers,
 	)
@@ -82,7 +82,7 @@ func (f *serviceEntryInformer) defaultInformer(client versioned.Interface, resyn
 }
 
 func (f *serviceEntryInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&networking_v1alpha3.ServiceEntry{}, f.defaultInformer)
+	return f.factory.InformerFor(&networkingv1alpha3.ServiceEntry{}, f.defaultInformer)
 }
 
 func (f *serviceEntryInformer) Lister() v1alpha3.ServiceEntryLister {

--- a/pkg/client/informers/externalversions/networking/v1alpha3/virtualservice.go
+++ b/pkg/client/informers/externalversions/networking/v1alpha3/virtualservice.go
@@ -22,7 +22,7 @@ package v1alpha3
 import (
 	time "time"
 
-	networking_v1alpha3 "github.com/aspenmesh/istio-client-go/pkg/apis/networking/v1alpha3"
+	networkingv1alpha3 "github.com/aspenmesh/istio-client-go/pkg/apis/networking/v1alpha3"
 	versioned "github.com/aspenmesh/istio-client-go/pkg/client/clientset/versioned"
 	internalinterfaces "github.com/aspenmesh/istio-client-go/pkg/client/informers/externalversions/internalinterfaces"
 	v1alpha3 "github.com/aspenmesh/istio-client-go/pkg/client/listers/networking/v1alpha3"
@@ -71,7 +71,7 @@ func NewFilteredVirtualServiceInformer(client versioned.Interface, namespace str
 				return client.NetworkingV1alpha3().VirtualServices(namespace).Watch(options)
 			},
 		},
-		&networking_v1alpha3.VirtualService{},
+		&networkingv1alpha3.VirtualService{},
 		resyncPeriod,
 		indexers,
 	)
@@ -82,7 +82,7 @@ func (f *virtualServiceInformer) defaultInformer(client versioned.Interface, res
 }
 
 func (f *virtualServiceInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&networking_v1alpha3.VirtualService{}, f.defaultInformer)
+	return f.factory.InformerFor(&networkingv1alpha3.VirtualService{}, f.defaultInformer)
 }
 
 func (f *virtualServiceInformer) Lister() v1alpha3.VirtualServiceLister {


### PR DESCRIPTION
Update Gopkg.toml to you newer version of client-go

NOTE: This will require a `make all` in the `github.com/aspenmesh/istio-client-go` package since the name of the repo is hardcoded in the `Makefile` and cannot be done through the fork.

Fixes #30 